### PR TITLE
Support multiple split accounts per transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Tax Slips only support letters and numbers. The only exceptions are round bracke
 2020-01-01 custom "tax-slip-settings" "slip-names" "t4a(p)"
 ```
 
-At all other places used, remove the brackes, e.g. use `t4ap`:
+At all other places used, remove the brackets, e.g. use `t4ap`:
 
 ```
 2020-01-01 open Income:CPP CAD

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Sometimes, if you split up your slip by stock, you don't want to create a separa
 
 1. Configure the tax slip and box via a customs directive instead of account meta data, as shown below
 1. Make sure the transaction with the posting to this account has another posting from an account configured via meta data for the same tax slip
-1. Make sure the other account has a symbol configured
+1. Make sure the other account has a symbol configured (Note: This also works on slips not split by symbol. E.g. When you share a tax expense account across the whole ledger, you can still add it to your employment slip this way)
 
 Example:
 
@@ -81,14 +81,18 @@ If multiple custom directives for the same setting exist, the latest one up unti
 
 #### Special Characters
 
-Tax Slips only support letters and numbers. The only exceptions are round brackets `()`. To use them, add them into the `tax-slip` meta data:
+Tax Slips only support letters and numbers. The only exceptions are round brackets `()`. To use them, add them into the `slip-names` meta data:
 
 ```
 2020-01-01 custom "tax-slip-settings" "slip-names" "t4a(p)"
 ```
 
-At all other places used, remove the brackes, e.g. use `t4ap`.
+At all other places used, remove the brackes, e.g. use `t4ap`:
 
+```
+2020-01-01 open Income:CPP CAD
+  t4ap: "Taxable CPP benefits (Box 20)"
+```
 
 ### Dates
 

--- a/Sources/SwiftBeanCountTax/TaxErrors.swift
+++ b/Sources/SwiftBeanCountTax/TaxErrors.swift
@@ -10,6 +10,8 @@ public enum TaxErrors: Error {
     case noTaxSlipConfigured(Int)
     /// When a tax slip has no currency defined (values are tax slip name and tax year)
     case noCurrencyDefined(String, Int)
+    /// When a transaction has a split account and more then one other tax split relevant account, and these accounts have different symbols
+    case splitAccountDifferentSymbols(String, String, String)
 }
 
 extension TaxErrors: LocalizedError {
@@ -21,6 +23,9 @@ extension TaxErrors: LocalizedError {
             return "There was no configured tax slip found for year \(year).\n\nMake sure your ledger contains a custom directive like this: YYYY-MM-DD custom \"\(MetaDataKeys.settings)\" \"\(MetaDataKeys.slipNames)\" \"tax-slip-name1\" \"tax-slip-name2\"\n\nAdditionally, check that the date is in or before the tax year you are tring to generate slips for."
         case let .noCurrencyDefined(slip, year):
             return "There was no currency for tax slip \(slip) in year \(year) found.\n\nMake sure your ledger contains a custom directive like this: YYYY-MM-DD custom \"\(MetaDataKeys.settings)\" \"\(MetaDataKeys.slipCurrency)\" \"tax-slip-name\" \"currencySymbol\"\n\nAdditionally, check that the date is in or before the tax year you are tring to generate slips for."
+        case let .splitAccountDifferentSymbols(transaction, symbols, descriptions):
+            return "The transaction \(transaction) has a split account plus multiple other tax slip relevant accounts. These accounts have different symbols or descriptions. This does not work, as it is unclear to which symbol the amount booked to the split account should be counted for. Symbols: \(symbols) Descriptions: \(descriptions)"
+
         }
     } // swiftlint:enable line_length
 }

--- a/Tests/SwiftBeanCountTaxTests/Helpers.swift
+++ b/Tests/SwiftBeanCountTaxTests/Helpers.swift
@@ -29,11 +29,11 @@ func basicLedger() throws -> Ledger {
         Posting(accountName: try AccountName("Expenses:Tax"), amount: Amount(number: -150, commoditySymbol: "EUR"))
     ]))
 
-    ledger.custom.append(Custom(date: date, name: MetaDataKeys.settings, values: [MetaDataKeys.slipNames, "Taxslip1", "Taxslip2"]))
-    ledger.custom.append(Custom(date: Date(timeIntervalSince1970: 1_618_477_015), name: MetaDataKeys.settings, values: [MetaDataKeys.slipNames, "Taxslip1"]))
-    ledger.custom.append(Custom(date: date, name: MetaDataKeys.settings, values: [MetaDataKeys.slipCurrency, "Taxslip1", "USD"]))
-    ledger.custom.append(Custom(date: date, name: MetaDataKeys.settings, values: [MetaDataKeys.slipCurrency, "Taxslip2", "EUR"]))
-    ledger.custom.append(Custom(date: date.advanced(by: -20_000), name: MetaDataKeys.settings, values: [MetaDataKeys.slipCurrency, "Taxslip2", "CAD"]))
+    ledger.custom.append(Custom(date: Date(timeIntervalSince1970: 1_610_463_065), name: MetaDataKeys.settings, values: [MetaDataKeys.slipNames, "Taxslip1", "Taxslip2"]))
+    ledger.custom.append(Custom(date: Date(timeIntervalSince1970: 1_547_304_665), name: MetaDataKeys.settings, values: [MetaDataKeys.slipNames, "Taxslip1"]))
+    ledger.custom.append(Custom(date: Date(timeIntervalSince1970: 1_547_304_665), name: MetaDataKeys.settings, values: [MetaDataKeys.slipCurrency, "Taxslip1", "USD"]))
+    ledger.custom.append(Custom(date: Date(timeIntervalSince1970: 1_641_999_065), name: MetaDataKeys.settings, values: [MetaDataKeys.slipCurrency, "Taxslip2", "EUR"]))
+    ledger.custom.append(Custom(date: date, name: MetaDataKeys.settings, values: [MetaDataKeys.slipCurrency, "Taxslip2", "CAD"]))
 
     return ledger
 }
@@ -132,6 +132,66 @@ func splitAccountLedger() throws -> Ledger {
     ledger.custom.append(Custom(date: date, name: MetaDataKeys.settings, values: [MetaDataKeys.slipNames, "Taxslip1", "Taxslip2"]))
     ledger.custom.append(Custom(date: date, name: MetaDataKeys.settings, values: [MetaDataKeys.slipCurrency, "Taxslip1", "USD"]))
     ledger.custom.append(Custom(date: date, name: MetaDataKeys.settings, values: [MetaDataKeys.slipCurrency, "Taxslip2", "EUR"]))
+    ledger.custom.append(Custom(date: date, name: MetaDataKeys.settings, values: [MetaDataKeys.account, "Taxslip1", "SplitBox3", "Expenses:Tax"]))
+
+    return ledger
+}
+
+func splitSymbolLedger() throws -> Ledger {
+    let ledger = Ledger()
+    let date = Date(timeIntervalSince1970: 1_650_013_015)
+
+    try ledger.add(Account(name: try AccountName("Assets:Account1:SYM"), metaData: ["Taxslip1": "TaxBox1"]))
+    try ledger.add(Account(name: try AccountName("Assets:Account2:SYM"), metaData: ["Taxslip1": "TaxBox4"]))
+    try ledger.add(Account(name: try AccountName("Assets:Account1:SYMB:Acc"), metaData: ["Taxslip1": "TaxBox2"]))
+    try ledger.add(Account(name: try AccountName("Expenses:Tax")))
+    try ledger.add(Account(name: try AccountName("Expenses:Other")))
+
+    try ledger.add(Commodity(symbol: "SYM"))
+    try ledger.add(Commodity(symbol: "SYMB", metaData: [MetaDataKeys.commodityName: "DescB"]))
+
+    ledger.add(Transaction(metaData: TransactionMetaData(date: date), postings: [
+        Posting(accountName: try AccountName("Assets:Account1:SYM"), amount: Amount(number: 100, commoditySymbol: "USD")),
+        Posting(accountName: try AccountName("Expenses:Tax"), amount: Amount(number: -80, commoditySymbol: "USD")),
+        Posting(accountName: try AccountName("Expenses:Other"), amount: Amount(number: -20, commoditySymbol: "USD"))
+    ]))
+    ledger.add(Transaction(metaData: TransactionMetaData(date: date), postings: [
+        Posting(accountName: try AccountName("Assets:Account2:SYM"), amount: Amount(number: 70, commoditySymbol: "USD")),
+        Posting(accountName: try AccountName("Expenses:Tax"), amount: Amount(number: -10, commoditySymbol: "USD")),
+        Posting(accountName: try AccountName("Expenses:Other"), amount: Amount(number: -60, commoditySymbol: "USD"))
+    ]))
+    ledger.add(Transaction(metaData: TransactionMetaData(date: date), postings: [
+        Posting(accountName: try AccountName("Assets:Account1:SYMB:Acc"), amount: Amount(number: 50, commoditySymbol: "USD")),
+        Posting(accountName: try AccountName("Expenses:Tax"), amount: Amount(number: -50, commoditySymbol: "USD"))
+    ]))
+
+    ledger.custom.append(Custom(date: date, name: MetaDataKeys.settings, values: [MetaDataKeys.slipNames, "Taxslip1"]))
+    ledger.custom.append(Custom(date: date, name: MetaDataKeys.settings, values: [MetaDataKeys.slipCurrency, "Taxslip1", "USD"]))
+    ledger.custom.append(Custom(date: date, name: MetaDataKeys.settings, values: [MetaDataKeys.account, "Taxslip1", "SplitBox3", "Expenses:Tax"]))
+
+    return ledger
+}
+
+func splitSymbolErrorLedger() throws -> Ledger {
+    let ledger = Ledger()
+    let date = Date(timeIntervalSince1970: 1_650_013_015)
+
+    try ledger.add(Account(name: try AccountName("Assets:Account1:SYM"), metaData: ["Taxslip1": "TaxBox1"]))
+    try ledger.add(Account(name: try AccountName("Assets:Account1:SYMB:Acc"), metaData: ["Taxslip1": "TaxBox2"]))
+    try ledger.add(Account(name: try AccountName("Expenses:Tax")))
+
+    try ledger.add(Commodity(symbol: "SYM"))
+    try ledger.add(Commodity(symbol: "SYMB", metaData: [MetaDataKeys.commodityName: "DescB"]))
+
+    ledger.add(Transaction(metaData: TransactionMetaData(date: date), postings: [
+        Posting(accountName: try AccountName("Assets:Account1:SYM"), amount: Amount(number: 100, commoditySymbol: "USD")),
+        Posting(accountName: try AccountName("Assets:Account1:SYMB:Acc"), amount: Amount(number: 50, commoditySymbol: "USD")),
+        Posting(accountName: try AccountName("Expenses:Tax"), amount: Amount(number: -150, commoditySymbol: "USD")),
+        Posting(accountName: try AccountName("Expenses:Other"), amount: Amount(number: -70, commoditySymbol: "USD"))
+    ]))
+
+    ledger.custom.append(Custom(date: date, name: MetaDataKeys.settings, values: [MetaDataKeys.slipNames, "Taxslip1"]))
+    ledger.custom.append(Custom(date: date, name: MetaDataKeys.settings, values: [MetaDataKeys.slipCurrency, "Taxslip1", "USD"]))
     ledger.custom.append(Custom(date: date, name: MetaDataKeys.settings, values: [MetaDataKeys.account, "Taxslip1", "SplitBox3", "Expenses:Tax"]))
 
     return ledger

--- a/Tests/SwiftBeanCountTaxTests/TaxErrorsTests.swift
+++ b/Tests/SwiftBeanCountTaxTests/TaxErrorsTests.swift
@@ -21,4 +21,10 @@ final class TaxErrorsTests: XCTestCase { // swiftlint:disable line_length
         XCTAssertEqual(error.localizedDescription, expectedDescription)
     }
 
+    func testSplitAccountDifferentSymbols() {
+        let error = TaxErrors.splitAccountDifferentSymbols("A", "b", "c")
+        let expectedDescription = "The transaction A has a split account plus multiple other tax slip relevant accounts. These accounts have different symbols or descriptions. This does not work, as it is unclear to which symbol the amount booked to the split account should be counted for. Symbols: b Descriptions: c"
+        XCTAssertEqual(error.localizedDescription, expectedDescription)
+    }
+
 } // swiftlint:enable line_length


### PR DESCRIPTION
Do not go through the postings on split accounts per posting of another tax slip relevant account.
This way we previously needed to remove the transaction once processed. This was to avoid that when a transaction has multiple accounts and a split account, it would be counted multiple times.

By going through the split accounts instead, we do not count it multiple times anymore, so we no longer need to remove it and can handle multiple split accounts per transaction.